### PR TITLE
Add child theme with custom product and cart templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# WooCommerce Theme Customization
+
+This repository contains a simple child theme of Twenty Twenty-Five adding custom product and cart templates.
+
+## Folder Structure
+
+- `wp-content/themes/twentytwentyfive-child` – child theme directory
+  - `functions.php` – registers meta fields for gifts and recommended products and enqueues CSS/JS.
+  - `style.css` – basic theme header.
+  - `js/main.js` – handles basic pricing logic on the product page.
+  - `woocommerce/` – template overrides
+    - `single-product.php` – custom product layout with radio buttons for purchase modes.
+    - `cart/cart.php` – custom cart template showing gifts and a pincode estimator.
+
+## Pricing Rules
+
+Subscription prices are calculated at 25% off the regular price. Both regular and subscription prices receive an additional 20% sale discount. The JavaScript in `js/main.js` demonstrates how this is applied on the product page when the customer switches purchase modes.
+
+## Meta Fields
+
+Two custom product meta fields can be configured on the product edit screen:
+
+- **Gift Product IDs** (`_ttf_gifts`): comma separated list of product IDs displayed as gifts in the cart.
+- **Recommended Product IDs** (`_ttf_recommended`): comma separated IDs of products suggested on the cart page if not already in the cart.
+
+These fields are saved with the product via `functions.php` and can be used in templates.

--- a/wp-content/themes/twentytwentyfive-child/functions.php
+++ b/wp-content/themes/twentytwentyfive-child/functions.php
@@ -1,0 +1,32 @@
+<?php
+// Enqueue child theme styles and scripts
+function ttf_child_enqueue_scripts() {
+    wp_enqueue_style('twentytwentyfive-child-style', get_stylesheet_uri(), [], filemtime(get_stylesheet_directory() . '/style.css'));
+    wp_enqueue_script('ttf-child-js', get_stylesheet_directory_uri() . '/js/main.js', ['jquery'], filemtime(get_stylesheet_directory() . '/js/main.js'), true);
+}
+add_action('wp_enqueue_scripts', 'ttf_child_enqueue_scripts');
+
+// Add custom meta fields for gifts and recommended products
+function ttf_child_add_product_meta() {
+    woocommerce_wp_text_input([
+        'id'          => '_ttf_gifts',
+        'label'       => __('Gift Product IDs', 'ttf-child'),
+        'description' => __('Comma separated product IDs that will be shown as gifts in cart', 'ttf-child'),
+    ]);
+    woocommerce_wp_text_input([
+        'id'          => '_ttf_recommended',
+        'label'       => __('Recommended Product IDs', 'ttf-child'),
+        'description' => __('Comma separated product IDs recommended in cart', 'ttf-child'),
+    ]);
+}
+add_action('woocommerce_product_options_general_product_data', 'ttf_child_add_product_meta');
+
+function ttf_child_save_product_meta($post_id) {
+    if (isset($_POST['_ttf_gifts'])) {
+        update_post_meta($post_id, '_ttf_gifts', sanitize_text_field($_POST['_ttf_gifts']));
+    }
+    if (isset($_POST['_ttf_recommended'])) {
+        update_post_meta($post_id, '_ttf_recommended', sanitize_text_field($_POST['_ttf_recommended']));
+    }
+}
+add_action('woocommerce_process_product_meta', 'ttf_child_save_product_meta');

--- a/wp-content/themes/twentytwentyfive-child/js/main.js
+++ b/wp-content/themes/twentytwentyfive-child/js/main.js
@@ -1,0 +1,20 @@
+(function($){
+    function updatePricing() {
+        var mode = $('input[name="purchase_mode"]:checked').val();
+        var base = parseFloat($('#product-price').data('price'));
+        var subscriptionPrice = base * 0.75;
+        var salePrice = base * 0.8;
+        var subSale = subscriptionPrice * 0.8;
+        if(mode === 'single') {
+            $('#product-price').text('$' + salePrice.toFixed(2));
+        } else if(mode === 'double') {
+            $('#product-price').text('$' + (salePrice*2).toFixed(2));
+        } else if(mode === 'single_sub') {
+            $('#product-price').text('$' + subSale.toFixed(2));
+        } else if(mode === 'double_sub') {
+            $('#product-price').text('$' + (subSale*2).toFixed(2));
+        }
+    }
+    $(document).on('change', 'input[name="purchase_mode"]', updatePricing);
+    $(document).ready(updatePricing);
+})(jQuery);

--- a/wp-content/themes/twentytwentyfive-child/style.css
+++ b/wp-content/themes/twentytwentyfive-child/style.css
@@ -1,0 +1,4 @@
+/*
+Theme Name: Twenty Twenty-Five Child
+Template: twentytwentyfive
+*/

--- a/wp-content/themes/twentytwentyfive-child/woocommerce/cart/cart.php
+++ b/wp-content/themes/twentytwentyfive-child/woocommerce/cart/cart.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WooCommerce Cart Template Override
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+get_header( 'shop' );
+?>
+<div class="ttf-cart-wrapper">
+    <?php woocommerce_breadcrumb(); ?>
+    <?php wc_print_notices(); ?>
+    <form class="woocommerce-cart-form" action="<?php echo esc_url( wc_get_cart_url() ); ?>" method="post">
+        <?php do_action( 'woocommerce_before_cart_table' ); ?>
+        <table class="shop_table shop_table_responsive cart" cellspacing="0">
+            <thead>
+            <tr>
+                <th class="product-name">Product</th>
+                <th class="product-total">Subtotal</th>
+            </tr>
+            </thead>
+            <tbody>
+                <?php foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) :
+                    $_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+                    if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 ) :
+                        ?>
+                        <tr class="woocommerce-cart-form__cart-item">
+                            <td class="product-name">
+                                <?php echo $_product->get_name(); ?>
+                                <?php
+                                $gifts = get_post_meta( $_product->get_id(), '_ttf_gifts', true );
+                                if ( $gifts ) {
+                                    echo '<div class="gifts">Gifts: ' . esc_html( $gifts ) . '</div>';
+                                }
+                                ?>
+                            </td>
+                            <td class="product-total">
+                                <?php echo wc_price( $_product->get_price() * $cart_item['quantity'] ); ?>
+                            </td>
+                        </tr>
+                    <?php endif; endforeach; ?>
+            </tbody>
+        </table>
+        <?php do_action( 'woocommerce_cart_actions' ); ?>
+    </form>
+    <div class="cart-collaterals">
+        <?php woocommerce_cart_totals(); ?>
+        <div class="pincode-check">
+            <input type="text" id="pincode" placeholder="Enter Pincode" />
+            <button type="button" id="check-pincode">Check</button>
+            <div id="delivery-estimate"></div>
+        </div>
+    </div>
+</div>
+<script>
+document.getElementById('check-pincode').addEventListener('click', function(){
+    var code = document.getElementById('pincode').value;
+    var estimate = '7 days';
+    if(code.startsWith('456')){ estimate = '2 days'; }
+    else if(code.endsWith('123')){ estimate = '4 days'; }
+    document.getElementById('delivery-estimate').textContent = 'Estimated Delivery: ' + estimate;
+});
+</script>
+<?php
+get_footer( 'shop' );

--- a/wp-content/themes/twentytwentyfive-child/woocommerce/single-product.php
+++ b/wp-content/themes/twentytwentyfive-child/woocommerce/single-product.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * WooCommerce Single Product Template Override
+ */
+
+defined('ABSPATH') || exit;
+
+get_header('shop');
+?>
+<div class="ttf-product-wrapper">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <div class="gallery">
+            <?php woocommerce_show_product_images(); ?>
+        </div>
+        <div class="summary">
+            <h1><?php the_title(); ?></h1>
+            <div id="product-price" data-price="<?php echo wc_get_price_to_display( $product ); ?>">
+                <?php echo wc_price(wc_get_price_to_display( $product )); ?>
+            </div>
+            <form class="cart" method="post" enctype='multipart/form-data'>
+                <fieldset>
+                    <label><input type="radio" name="purchase_mode" value="single_sub" checked>Single Drink Subscription</label>
+                    <label><input type="radio" name="purchase_mode" value="double_sub">Double Drink Subscription</label>
+                    <label><input type="radio" name="purchase_mode" value="single">Try Once Single</label>
+                    <label><input type="radio" name="purchase_mode" value="double">Try Once Double</label>
+                </fieldset>
+                <?php woocommerce_template_single_add_to_cart(); ?>
+            </form>
+            <?php the_content(); ?>
+        </div>
+    <?php endwhile; ?>
+</div>
+<?php
+get_footer('shop');


### PR DESCRIPTION
## Summary
- create Twenty Twenty-Five child theme
- implement WooCommerce single product and cart template overrides
- add meta fields for gifts and recommended products
- include JS for basic pricing logic
- document structure and pricing rules

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68481d27688c8323914ae5b59c15e87e