### PR TITLE
Remove zipped child theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore archives
+*.zip

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ Two custom product meta fields can be configured on the product edit screen:
 - **Recommended Product IDs** (`_ttf_recommended`): comma separated IDs of products suggested on the cart page if not already in the cart.
 
 These fields are saved with the product via `functions.php` and can be used in templates.
+
+## Packaging the Theme
+
+Binary files are not tracked in this repository. To create an installable archive, run:
+
+```bash
+zip -r twentytwentyfive-child.zip wp-content/themes/twentytwentyfive-child
+```
+
+Upload the resulting `twentytwentyfive-child.zip` through **Appearance → Themes → Add New → Upload Theme** in your WordPress admin.


### PR DESCRIPTION
## Summary
- remove binary theme archive and ignore zip files
- document how to create the installable archive

## Testing
- `unzip -l twentytwentyfive-child.zip` *(fails: no such file, as file removed)*

------
https://chatgpt.com/codex/tasks/task_e_685a38b4f0b08323908fbbf0faacb663